### PR TITLE
Fix zero reading if ActivePower if not checked before checking Current

### DIFF
--- a/src/HLW8012.cpp
+++ b/src/HLW8012.cpp
@@ -72,7 +72,7 @@ double HLW8012::getCurrent() {
 
     // Power measurements are more sensitive to switch offs,
     // so we first check if power is 0 to set _current to 0 too
-    if (_power == 0) {
+    if (getActivePower() == 0) {
         _current_pulse_width = 0;
 
     } else if (_use_interrupts) {


### PR DESCRIPTION
I noticed that if I read only "`getApparentPower()`" and "`getVoltage()`" there will by always zero returned by "`getApparentPower()`".  
It seems that "`_power`" is not updated automatically other than by "`getActivePower()`" (or by functions which run "`getActivePower()`" like "`getCurrent()`" "`getReactivePower()`" or "`getPowerFactor()`").

This change makes sure that the "`_power`" value is updated and it fixed issue for me.

How to reproduce issue:  
Try to measure "`getApparentPower()`" without checking other values.