### PR TITLE
Improve resolution + fix crash

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "https://github.com/xoseperez/hlw8012.git"
     },
-    "version": "1.1.1",
+    "version": "1.1.2",
     "license": "LGPL-3.0",
     "exclude": "tests",
     "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=HLW8012
-version=1.1.1
+version=1.1.2
 author=Xose Pérez <xose.perez@gmail.com>
 maintainer=Xose Pérez <xose.perez@gmail.com>
 sentence=HLW8012 for Arduino / ESP8216

--- a/src/HLW8012.cpp
+++ b/src/HLW8012.cpp
@@ -22,6 +22,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <Arduino.h>
 #include "HLW8012.h"
 
+#if defined(ESP8266)
+#include <c_types.h>
+#elif defined(ESP32)
+#include <esp_attr.h>
+#else
+#define IRAM_ATTR
+#endif
+
 void HLW8012::begin(
     unsigned char cf_pin,
     unsigned char cf1_pin,
@@ -68,7 +76,7 @@ hlw8012_mode_t HLW8012::toggleMode() {
     return new_mode;
 }
 
-double HLW8012::getCurrent() {
+float HLW8012::getCurrent() {
 
     // Power measurements are more sensitive to switch offs,
     // so we first check if power is 0 to set _current to 0 too
@@ -82,38 +90,41 @@ double HLW8012::getCurrent() {
         _current_pulse_width = pulseIn(_cf1_pin, HIGH, _pulse_timeout);
     }
 
-    _current = (_current_pulse_width > 0) ? _current_multiplier / _current_pulse_width / 2 : 0;
+    const unsigned int current_pulse_width = _current_pulse_width;
+    _current = (current_pulse_width > 0) ? _current_multiplier / static_cast<float>(current_pulse_width) / 2.0f : 0.0f;
     return _current;
 
 }
 
-unsigned int HLW8012::getVoltage() {
+float HLW8012::getVoltage() {
     if (_use_interrupts) {
         _checkCF1Signal();
     } else if (_mode != _current_mode) {
         _voltage_pulse_width = pulseIn(_cf1_pin, HIGH, _pulse_timeout);
     }
-    _voltage = (_voltage_pulse_width > 0) ? _voltage_multiplier / _voltage_pulse_width / 2 : 0;
+    const unsigned int voltage_pulse_width = _voltage_pulse_width;
+    _voltage = (voltage_pulse_width > 0) ? _voltage_multiplier / static_cast<float>(voltage_pulse_width) / 2.0f : 0.0f;
     return _voltage;
 }
 
-unsigned int HLW8012::getActivePower() {
+float HLW8012::getActivePower() {
     if (_use_interrupts) {
         _checkCFSignal();
     } else {
         _power_pulse_width = pulseIn(_cf_pin, HIGH, _pulse_timeout);
     }
-    _power = (_power_pulse_width > 0) ? _power_multiplier / _power_pulse_width / 2 : 0;
+    const unsigned int power_pulse_width = _power_pulse_width;
+    _power = (power_pulse_width > 0) ? _power_multiplier / static_cast<float>(power_pulse_width) / 2.0f : 0.0f;
     return _power;
 }
 
-unsigned int HLW8012::getApparentPower() {
-    double current = getCurrent();
+float HLW8012::getApparentPower() {
+    float current = getCurrent();
     unsigned int voltage = getVoltage();
     return voltage * current;
 }
 
-unsigned int HLW8012::getReactivePower() {
+float HLW8012::getReactivePower() {
     unsigned int active = getActivePower();
     unsigned int apparent = getApparentPower();
     if (apparent > active) {
@@ -123,15 +134,15 @@ unsigned int HLW8012::getReactivePower() {
     }
 }
 
-double HLW8012::getPowerFactor() {
-    unsigned int active = getActivePower();
-    unsigned int apparent = getApparentPower();
-    if (active > apparent) return 1;
-    if (apparent == 0) return 0;
-    return (double) active / apparent;
+float HLW8012::getPowerFactor() {
+    const float active = getActivePower();
+    const float apparent = getApparentPower();
+    if (active > apparent) return 1.0f;
+    if (apparent == 0) return 0.0f;
+    return active / apparent;
 }
 
-unsigned long HLW8012::getEnergy() {
+float HLW8012::getEnergy() {
 
     // Counting pulses only works in IRQ mode
     if (!_use_interrupts) return 0;
@@ -142,34 +153,35 @@ unsigned long HLW8012::getEnergy() {
     f = N/t (N=pulse count, t = time)
     E = P*t = m*N  (E=energy)
     */
-    return _pulse_count * _power_multiplier / 1000000. / 2;
+    const float pulse_count = _cf_pulse_count;
+    return pulse_count * _power_multiplier / 1000000.0f / 2.0f;
 
 }
 
 void HLW8012::resetEnergy() {
-    _pulse_count = 0;
+    _cf_pulse_count = 0;
 }
 
-void HLW8012::expectedCurrent(double value) {
-    if (_current == 0) getCurrent();
-    if (_current > 0) _current_multiplier *= (value / _current);
+void HLW8012::expectedCurrent(float value) {
+    if (static_cast<int>(_current) == 0) getCurrent();
+    if (static_cast<int>(_current) > 0) _current_multiplier *= (value / _current);
 }
 
-void HLW8012::expectedVoltage(unsigned int value) {
-    if (_voltage == 0) getVoltage();
-    if (_voltage > 0) _voltage_multiplier *= ((double) value / _voltage);
+void HLW8012::expectedVoltage(float value) {
+    if (static_cast<int>(_voltage) == 0) getVoltage();
+    if (static_cast<int>(_voltage) > 0) _voltage_multiplier *= (value / _voltage);
 }
 
-void HLW8012::expectedActivePower(unsigned int value) {
-    if (_power == 0) getActivePower();
-    if (_power > 0) _power_multiplier *= ((double) value / _power);
+void HLW8012::expectedActivePower(float value) {
+    if (static_cast<int>(_power) == 0) getActivePower();
+    if (static_cast<int>(_power) > 0) _power_multiplier *= (value / _power);
 }
 
 void HLW8012::resetMultipliers() {
     _calculateDefaultMultipliers();
 }
 
-void HLW8012::setResistors(double current, double voltage_upstream, double voltage_downstream) {
+void HLW8012::setResistors(float current, float voltage_upstream, float voltage_downstream) {
     if (voltage_downstream > 0) {
         _current_resistor = current;
         _voltage_resistor = (voltage_upstream + voltage_downstream) / voltage_downstream;
@@ -177,37 +189,48 @@ void HLW8012::setResistors(double current, double voltage_upstream, double volta
     }
 }
 
-void ICACHE_RAM_ATTR HLW8012::cf_interrupt() {
-    unsigned long now = micros();
+void IRAM_ATTR HLW8012::cf_interrupt() {
+    const unsigned long now = micros();
     _power_pulse_width = now - _last_cf_interrupt;
     _last_cf_interrupt = now;
-    _pulse_count++;
+    _cf_pulse_count++;
 }
 
-void ICACHE_RAM_ATTR HLW8012::cf1_interrupt() {
+void IRAM_ATTR HLW8012::cf1_interrupt() {
 
-    unsigned long now = micros();
+    const unsigned long now = micros();
+    const unsigned long time_since_first = now - _first_cf1_interrupt;
 
-    if ((now - _first_cf1_interrupt) > _pulse_timeout) {
-
-        unsigned long pulse_width;
+    // The first few pulses after switching will be unstable
+    // Collect pulses in this mode for some time
+    // On very few pulses, use the last one collected in this period.
+    // On many pulses, compute the average over a longer period to get a more stable reading.
+    // This may also increase resolution on higher frequencies.
+    if (time_since_first > _pulse_timeout) {
+        // Copy value first as it is volatile
+        const unsigned long last_cf1_interrupt = _last_cf1_interrupt;
+        const unsigned long pulse_width = 
+          (last_cf1_interrupt == _first_cf1_interrupt) 
+            ? 0 
+            : (_cf1_pulse_count < 10) 
+              ? (now - last_cf1_interrupt) // long pulses, use the last one as it is probably the most stable one
+              : (time_since_first / _cf1_pulse_count);
         
-        if (_last_cf1_interrupt == _first_cf1_interrupt) {
-            pulse_width = 0;
-        } else {
-            pulse_width = now - _last_cf1_interrupt;
-        }
-
         if (_mode == _current_mode) {
             _current_pulse_width = pulse_width;
         } else {
             _voltage_pulse_width = pulse_width;
         }
-
-        _mode = 1 - _mode;
+        
+        // Copy value first as it is volatile
+        const unsigned char mode = 1 - _mode;
         digitalWrite(_sel_pin, _mode);
+        _mode = mode;
+        // Keep track of when the SEL pin was switched.
         _first_cf1_interrupt = now;
-
+        _cf1_pulse_count = 0;
+    } else {
+        ++_cf1_pulse_count;
     }
 
     _last_cf1_interrupt = now;
@@ -219,13 +242,20 @@ void HLW8012::_checkCFSignal() {
 }
 
 void HLW8012::_checkCF1Signal() {
-    if ((micros() - _last_cf1_interrupt) > _pulse_timeout) {
+    const unsigned long now = micros();
+    if ((now - _last_cf1_interrupt) > _pulse_timeout) {
         if (_mode == _current_mode) {
             _current_pulse_width = 0;
         } else {
             _voltage_pulse_width = 0;
         }
-        toggleMode();
+        // Copy value first as it is volatile
+        const unsigned char mode = 1 - _mode;
+        digitalWrite(_sel_pin, _mode);
+        _mode = mode;
+        if (_use_interrupts) {
+            _last_cf1_interrupt = _first_cf1_interrupt = now;
+        }
     }
 }
 

--- a/src/HLW8012.h
+++ b/src/HLW8012.h
@@ -79,63 +79,65 @@ class HLW8012 {
             unsigned long pulse_timeout = PULSE_TIMEOUT);
 
         void setMode(hlw8012_mode_t mode);
+
         hlw8012_mode_t getMode();
         hlw8012_mode_t toggleMode();
 
-        double getCurrent();
-        unsigned int getVoltage();
-        unsigned int getActivePower();
-        unsigned int getApparentPower();
-        double getPowerFactor();
-        unsigned int getReactivePower();
-        unsigned long getEnergy(); //in Ws
+        float getCurrent();
+        float getVoltage();
+        float getActivePower();
+        float getApparentPower();
+        float getPowerFactor();
+        float getReactivePower();
+        float getEnergy(); //in Ws
         void resetEnergy();
 
-        void setResistors(double current, double voltage_upstream, double voltage_downstream);
+        void setResistors(float current, float voltage_upstream, float voltage_downstream);
 
-        void expectedCurrent(double current);
-        void expectedVoltage(unsigned int current);
-        void expectedActivePower(unsigned int power);
+        void expectedCurrent(float current);
+        void expectedVoltage(float current);
+        void expectedActivePower(float power);
 
-        double getCurrentMultiplier() { return _current_multiplier; };
-        double getVoltageMultiplier() { return _voltage_multiplier; };
-        double getPowerMultiplier() { return _power_multiplier; };
+        float getCurrentMultiplier() { return _current_multiplier; };
+        float getVoltageMultiplier() { return _voltage_multiplier; };
+        float getPowerMultiplier() { return _power_multiplier; };
 
-        void setCurrentMultiplier(double current_multiplier) { _current_multiplier = current_multiplier; };
-        void setVoltageMultiplier(double voltage_multiplier) { _voltage_multiplier = voltage_multiplier; };
-        void setPowerMultiplier(double power_multiplier) { _power_multiplier = power_multiplier; };
+        void setCurrentMultiplier(float current_multiplier) { _current_multiplier = current_multiplier; };
+        void setVoltageMultiplier(float voltage_multiplier) { _voltage_multiplier = voltage_multiplier; };
+        void setPowerMultiplier(float power_multiplier) { _power_multiplier = power_multiplier; };
         void resetMultipliers();
 
     private:
 
-        unsigned char _cf_pin;
-        unsigned char _cf1_pin;
-        unsigned char _sel_pin;
+        unsigned char _cf_pin = 0;
+        unsigned char _cf1_pin = 0;
+        unsigned char _sel_pin = 0;
 
-        double _current_resistor = R_CURRENT;
-        double _voltage_resistor = R_VOLTAGE;
+        float _current_resistor = R_CURRENT;
+        float _voltage_resistor = R_VOLTAGE;
 
-        double _current_multiplier; // Unit: us/A
-        double _voltage_multiplier; // Unit: us/V
-        double _power_multiplier;   // Unit: us/W
+        float _current_multiplier = 0.0; // Unit: us/A
+        float _voltage_multiplier = 0.0; // Unit: us/V
+        float _power_multiplier = 0.0;   // Unit: us/W
 
         unsigned long _pulse_timeout = PULSE_TIMEOUT;    //Unit: us
         volatile unsigned long _voltage_pulse_width = 0; //Unit: us
         volatile unsigned long _current_pulse_width = 0; //Unit: us
         volatile unsigned long _power_pulse_width = 0;   //Unit: us
-        volatile unsigned long _pulse_count = 0;
 
-        double _current = 0;
-        unsigned int _voltage = 0;
-        unsigned int _power = 0;
+        float _current = 0;
+        float _voltage = 0;
+        float _power = 0;
 
         unsigned char _current_mode = HIGH;
-        volatile unsigned char _mode;
+        volatile unsigned char _mode = 0;
 
         bool _use_interrupts = true;
         volatile unsigned long _last_cf_interrupt = 0;
         volatile unsigned long _last_cf1_interrupt = 0;
         volatile unsigned long _first_cf1_interrupt = 0;
+        volatile unsigned long _cf_pulse_count = 0;
+        volatile unsigned long _cf1_pulse_count = 0;
 
         void _checkCFSignal();
         void _checkCF1Signal();


### PR DESCRIPTION
Crash:
```c++
_voltage = (voltage_pulse_width > 0) ? _voltage_multiplier / voltage_pulse_width / 2 : 0;
```
Since `voltage_pulse_width` is volatile, it may be set to 0 in an interrupt handling right after it was checked for not being zero.


Resolution improvement:
When measuring 230V mains voltage on a Sonoff POW r1, it reported the voltage with a resolution of about 8V. Changing some types to float instead of int does improve it slightly.

The actual measurement was done by measuring the "last" pulse of a measurement period due to instability of the pulse frequency right after setting it. For 222 & 230V mains this was a pulse width of roughly 970 - 1000 usec. This is also roughly the jitter of an ESP8266 when handling interrupts.

The change I made was to keep track of both the measurement duration, the last pulse width and count the nr. of pulses. If the nr of pulses is low, the pulse duration is way longer than the jitter, so then we can take the last pulse width. If the nr. of pulses is high, then the outliers of the first few pulses won't matter a lot. Also "instability" does work both ways and thus evens out.

Now the resolution of the measurements from the CF1 pin is way more usable and also quite accurate. Compared it with the CSE7766 used in a Sonoff POW r2 and calibrated both using a proper multimeter. Both differ in the order of 0.1V from each other and the multimeter.

A before and after:
![image](https://user-images.githubusercontent.com/3751318/199714903-d23e62dd-acb3-4668-8a42-2a31b2963a8f.png)


Another change I made is to get rid of `double` variables.
They're not really needed here and give quite a lot of overhead as `double` computations are done in software.